### PR TITLE
commons-189-recommendations-not-working

### DIFF
--- a/classes/class-hc-suggestions-widget.php
+++ b/classes/class-hc-suggestions-widget.php
@@ -107,7 +107,7 @@ class HC_Suggestions_Widget extends WP_Widget {
 				printf(
 					'<div id="%s" data-hc-suggestions-query="%s" data-hc-suggestions-type="%s"></div>',
 					esc_attr( $tab_id_prefix . $identifier ),
-					implode( ' OR ', $user_terms ),
+					implode( ' ', $user_terms ),
 					$identifier
 				);
 			}


### PR DESCRIPTION
Primarily, this updates the plugin for compatibility with the newer versions of ElasticPress and ElasticSearch. It also fixes the filtering of a user's own posts from the recommendations.

Previously, the plugin created a search string from a user's academic interests by combining the interests together into a single string joined by 'OR's. So if a user's academic interests were Philosophy of Science and Social Epistemology, the search string would be ```Philosophy of Science OR Social Epistemology```. In the current version of ElasticPress, the 's' query parameter is treated as a single phrase, so rather than searching for 'Philosophy of Science' or 'Social Epistemology', it was searching for 'Philosophy of Science OR Social Epistemology'. This all but guarantees no results.

This PR adds a [filter](https://github.com/MESH-Research/hc-suggestions/compare/main...commons-189-recommendations-not-working#diff-b5879e691ff4ba69051da62e99d907ea22f1069f2df82a39775a44ffcaa4d07dR195) that alters the  ElasticPress query to convert it from a phrase search to a normal match search joined by 'OR'. Academic interests are now concatenated by spaces, so in the previous example the search string would be ```Philosophy of Science Social Epistemoloy```. On the ElasticSearch end, this becomes ```'Philosophy' OR 'of' OR 'Science' OR 'Social' OR 'Epistemology'```. Getting good results depends on how ElasticSearch ranks query results. It might be worth finding a better way to construct this query.

Additionally, this PR corrects how the plugin filters out a user's own posts from their recommendations. The plugin generates a list of IDs of posts authored by the user and adds them the query in the ```post__not_in``` field. Previously, multiple layers of sanitization and escaping corrupted the query for a user's posts such that no post IDs were ever returned and nothing was ever filtered. This PR removes the redundant sanitization ([here](https://github.com/MESH-Research/hc-suggestions/compare/main...commons-189-recommendations-not-working#diff-b5879e691ff4ba69051da62e99d907ea22f1069f2df82a39775a44ffcaa4d07dR157)).

This PR makes the plugin functional, but it is probably worth another look at whether it could be improved to give better search results.